### PR TITLE
Revert "feat(container): update image spegel to 0.4.0"

### DIFF
--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: spegel
-      version: 0.4.0
+      version: 0.3.0
       sourceRef:
         kind: HelmRepository
         name: spegel


### PR DESCRIPTION
## Summary

This PR reverts the Spegel update from 0.3.0 to 0.4.0 (PR #6304) due to an undocumented breaking change that causes deployment failures.

## Issue

The Helm chart 0.4.0 modifies the DaemonSet selector labels by adding `app.kubernetes.io/component: spegel`, which is an **immutable field** in Kubernetes. This causes the upgrade to fail with:

```
DaemonSet.apps "spegel" is invalid: spec.selector: Invalid value: field is immutable
```

## Current State

- Helm has **successfully auto-rolled back** to version 0.3.0 (4 upgrade attempts failed, all rolled back)
- The cluster is stable and running Spegel 0.3.0
- This revert ensures the GitOps repository matches the deployed state

## Breaking Change Not Documented

The release notes for v0.4.0 do not mention this breaking change. The changelog only notes:
- Deprecation of "resolve latest" in favor of registry filters
- Various new features and improvements
- **No mention** of selector label changes requiring DaemonSet recreation

## Migration Path

To upgrade to 0.4.0 in the future, the existing DaemonSet must be **manually deleted first**, which will cause temporary downtime for the local registry mirror:

```bash
kubectl delete daemonset spegel -n kube-system
# Then apply the 0.4.0 update
```

This is not suitable for automated updates via Renovate.

## Related

- Original PR: #6304
- Spegel release: https://github.com/spegel-org/spegel/releases/tag/v0.4.0