### PR TITLE
Revert "fix(container): update image mariadb to 21.0.8"

### DIFF
--- a/kubernetes/apps/selfhosted/monica/database/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/monica/database/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: mariadb
-      version: 21.0.8
+      version: 21.0.3
       sourceRef:
         kind: HelmRepository
         name: bitnami


### PR DESCRIPTION
## Summary
This PR reverts the MariaDB chart update from version 21.0.8 back to 21.0.3 due to a critical deployment failure.

## Issue
PR #6249 was merged but the deployment failed with the following error:
```
failed to pull and unpack image "docker.io/bitnami/mariadb:11.8.3-debian-12-r0": 
docker.io/bitnami/mariadb:11.8.3-debian-12-r0: not found
```

## Root Cause
The container image `docker.io/bitnami/mariadb:11.8.3-debian-12-r0` referenced by chart version 21.0.8 does not exist in the Docker registry. This is likely a packaging issue with the upstream Bitnami chart.

## Resolution
Reverting to the previously working version 21.0.3 which uses a confirmed available image.

## Impact
- monica-db HelmRelease is currently in a failed state
- This revert will restore the working MariaDB deployment

Generated with [Claude Code](https://claude.com/claude-code)